### PR TITLE
fixed alb configurations

### DIFF
--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -42,6 +42,8 @@ resource "aws_lb_listener" "ecs-alb-listener-http" {
             status_code = "HTTP_301"
         }
     }
+
+    depends_on = [aws_lb.alb, aws_lb_target_group.target_group]
 }
 
 resource "aws_lb_listener" "ecs-alb-listener-https" {
@@ -54,6 +56,8 @@ resource "aws_lb_listener" "ecs-alb-listener-https" {
         type             = "forward"
         target_group_arn = aws_lb_target_group.target_group.arn
     }
+
+    depends_on = [aws_lb.alb, aws_lb_target_group.target_group]
 }
 
 resource "aws_cloudwatch_log_group" "ecs" {


### PR DESCRIPTION
### **User description**
fixed alb configurations


___

### **PR Type**
enhancement


___

### **Description**
- Added `depends_on` attribute to the `aws_lb_listener` resources for both HTTP and HTTPS listeners to ensure proper dependency management.
- This change ensures that the ALB and target group resources are created before the listeners, preventing potential configuration issues.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ecs.tf</strong><dd><code>Add dependencies to ALB listener configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/modules/ecs/ecs.tf

<li>Added <code>depends_on</code> attribute to <code>aws_lb_listener</code> resources.<br> <li> Ensured ALB and target group dependencies are explicitly defined.<br>


</details>


  </td>
  <td><a href="https://github.com/Pramod858/Multi-Tier-PHP-DevOps/pull/11/files#diff-e03338482821be6dbceeda56ef0ab8e076a03212032172e62a8bb4c57a59f949">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information